### PR TITLE
Remove useless EXPECT_EQ comparing the same 64ints

### DIFF
--- a/tests/latency/latency_perf.cpp
+++ b/tests/latency/latency_perf.cpp
@@ -281,8 +281,6 @@ static int _latency_imu_thread(void *param)
                 break;
             }
 
-            EXPECT_EQ(imu.acc_timestamp_usec, imu.acc_timestamp_usec);
-
             // Save data to each of the queues
             g_lock_mutex.lock();
             g_time_c.push_back(time);


### PR DESCRIPTION
The EXPECT_EQ compares the same unsigned 64-bit ints.  This seems like it was probably a typo.